### PR TITLE
Github workflow dont check bin folder

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Validate
         run: make validate
       - name: Check Format
-        run: npx prettier --check schema.json "vendor/**/*.yaml" "bin/**/*.js"
+        run: npx prettier --check schema.json "vendor/**/*.yaml"


### PR DESCRIPTION
#### Summary
This pull request includes a small change to the `.github/workflows/validate.yml` file. 

...

#### Changes
The change removes the `bin/**/*.js` files from the list of paths checked by Prettier in the "Check Format" step.

#### Notes for Reviewers
The bin folder was causing issues with the prettier validation it will cause it to fail even though the file didn't have any formatting issues.

...
